### PR TITLE
Fix :Data().Scenario().injectDependencies() is not a function

### DIFF
--- a/lib/data/dataScenarioConfig.js
+++ b/lib/data/dataScenarioConfig.js
@@ -61,6 +61,24 @@ class DataScenarioConfig {
     this.scenarios.forEach(scenario => scenario.tag(tagName));
     return this;
   }
+
+  /**
+     * Pass in additional objects to inject into test
+     * @param {*} obj
+     */
+    inject(obj) {
+      this.scenarios.forEach(scenario => scenario.inject(obj));
+      return this;
+    }
+  
+    /**
+       * Dynamically injects dependencies, see https://codecept.io/pageobjects/#dynamic-injection
+       * @param {*} dependencies
+       */
+    injectDependencies(dependencies) {
+      this.scenarios.forEach(scenario => scenario.injectDependencies(dependencies));
+      return this;
+    }
 }
 
 module.exports = DataScenarioConfig;


### PR DESCRIPTION
Fix: "TypeError: scenario.injectDependencies is not a function" when use Data().Scenario().injectDependencies() or Data().Scenario().inject();
